### PR TITLE
fix: copy-paste variable name errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ def load_vgg(sess, vgg_path):
     Load Pretrained VGG Model into TensorFlow.
     :param sess: TensorFlow Session
     :param vgg_path: Path to vgg folder, containing "variables/" and "saved_model.pb"
-    :return: Tuple of Tensors from VGG model (image_input, keep_prob, layer3_out, layer4_out, layer3_out)
+    :return: Tuple of Tensors from VGG model (image_input, keep_prob, layer3_out, layer4_out, layer7_out)
     """
     # TODO: Implement function
     return None, None, None, None, None

--- a/project_tests.py
+++ b/project_tests.py
@@ -150,5 +150,5 @@ def test_for_kitti_dataset(data_dir):
     assert not (training_images_count == training_labels_count == testing_images_count == 0),\
         'Kitti dataset not found. Extract Kitti dataset in {}'.format(kitti_dataset_path)
     assert training_images_count == 289, 'Expected 289 training images, found {} images.'.format(training_images_count)
-    assert training_labels_count == 289, 'Expected 289 training images, found {} images.'.format(training_images_count)
-    assert testing_images_count == 290, 'Expected 290 training images, found {} images.'.format(training_images_count)
+    assert training_labels_count == 289, 'Expected 289 training labels, found {} labels.'.format(training_labels_count)
+    assert testing_images_count == 290, 'Expected 290 testing images, found {} images.'.format(testing_images_count)


### PR DESCRIPTION
Looks like some variable names have wrong names due to copy-pasting errors.